### PR TITLE
Fixed order of frames saving to get correct tracking

### DIFF
--- a/Source/crops.py
+++ b/Source/crops.py
@@ -109,7 +109,7 @@ def generate_random_crops(input, n_files, patterns, extension):
 
     if patterns is None or len(patterns) == 0:
         patterns = [""]
-
+    print(patterns)
     random_files = random.sample(
         [f for f in sorted(glob.glob(os.path.join(input, f"*{extension}")))
         if all(p in os.path.basename(f) for p in patterns)],

--- a/Source/finetune.py
+++ b/Source/finetune.py
@@ -166,8 +166,8 @@ from pathlib import Path
 def split_dataset(finetune_dir, train_ratio=0.8, seed=42):
     random.seed(seed)
 
-    finetune_dir = Path(finetune_dir)
-    output_dir = finetune_dir.parent 
+    finetune_dir = Path(finetune_dir)   # TODO Supposed to be output directory. Calling the variable finetune_dir might be misleading. 
+    output_dir = finetune_dir.parent    
     train_dir = output_dir / "Train"    # When working with Path object, we can use / instead of os.path.join
     test_dir = output_dir / "Test"
     
@@ -175,7 +175,7 @@ def split_dataset(finetune_dir, train_ratio=0.8, seed=42):
     for d in [train_dir, test_dir]:
         d.mkdir(parents=True, exist_ok=True)
 
-    # Lister tous les fichiers *_seg.npy (indique une image complète annotée)
+    # Lister tous les fichiers *_seg.npy 
     seg_files = list(finetune_dir.glob("*_seg.npy"))
     basenames = [f.stem.replace("_seg", "") for f in seg_files]
 

--- a/Source/segmentation.py
+++ b/Source/segmentation.py
@@ -285,7 +285,7 @@ def tracking_centroids(input_folder):
                     #print(frame_mask[int(centroid_y), int(centroid_x)])
 
                 if t == 0:
-                    print("t0", t)                                                              # First frame: Initialize tracking
+                                                                                  # First frame: Initialize tracking
                     relabeled_masks[t] = frame_mask                                     # Copy original labels
 
                     # # for label_id in np.unique(frame_mask):                              # Loop over all unique labels in the original mask  


### PR DESCRIPTION
The files (raw, masks, grads) were re not saved in the same order of frames when dealing with stacks, so masks didn't match, hence tracking couldn't follow.